### PR TITLE
Fix #1

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,7 @@ CheckOptions:
   - key:             readability-identifier-naming.MacroDefinitionCase
     value:           UPPER_CASE
   - key:             readability-identifier-naming.MacroDefinitionIgnoreRegexp
-    value:           .*_EXPORTS
+    value:           *_EXPORTS
   - key:             readability-identifier-naming.MemberCase
     value:           lower_case
   - key:             readability-identifier-naming.MemberSuffix


### PR DESCRIPTION
Added regex to ignore macro definitions {PROJECT_NAME}_EXPORTS`.